### PR TITLE
Change order of modifiers so 'AltGr' will be checked before 'Alt'

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,4 @@
 const modifiers = /^(CommandOrControl|CmdOrCtrl|Command|Cmd|Control|Ctrl|AltGr|Option|Alt|Shift|Super)/i;
-
 const keyCodes = /^(Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]'])/i;
 export const UNSUPPORTED = {};
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-const modifiers = /^(CommandOrControl|CmdOrCtrl|Command|Cmd|Control|Ctrl|Alt|Option|AltGr|Shift|Super)/i;
+const modifiers = /^(CommandOrControl|CmdOrCtrl|Command|Cmd|Control|Ctrl|AltGr|Option|Alt|Shift|Super)/i;
+
 const keyCodes = /^(Plus|Space|Tab|Backspace|Delete|Insert|Return|Enter|Up|Down|Left|Right|Home|End|PageUp|PageDown|Escape|Esc|VolumeUp|VolumeDown|VolumeMute|MediaNextTrack|MediaPreviousTrack|MediaStop|MediaPlayPause|PrintScreen|F24|F23|F22|F21|F20|F19|F18|F17|F16|F15|F14|F13|F12|F11|F10|F9|F8|F7|F6|F5|F4|F3|F2|F1|[0-9A-Z)!@#$%^&*(:+<_>?~{|}";=,\-./`[\\\]'])/i;
 export const UNSUPPORTED = {};
 

--- a/test.js
+++ b/test.js
@@ -38,7 +38,8 @@ test('Command shortcuts are not converted on Windows and Linux', t => {
 	if (process.platform === 'darwin') {
 		t.deepEqual(event, {
 			metaKey: true,
-			key: 'v'
+			key: 'v',
+			code: 'KeyV'
 		});
 	} else {
 		t.deepEqual(event, {
@@ -53,7 +54,8 @@ test('Options shortcuts are not converted on Windows and Linux', t => {
 	if (process.platform === 'darwin') {
 		t.deepEqual(event, {
 			altKey: true,
-			key: 'v'
+			key: 'v',
+			code: 'KeyV'
 		});
 	} else {
 		t.deepEqual(event, {


### PR DESCRIPTION
This resolves following issue: https://github.com/parro-it/keyboardevent-from-electron-accelerator/issues/11